### PR TITLE
Fix: Table#resize crash without error

### DIFF
--- a/ext/LiteRGSS/Table.cpp
+++ b/ext/LiteRGSS/Table.cpp
@@ -82,7 +82,10 @@ VALUE rb_Table_initialize(int argc, VALUE* argv, VALUE self)
 	bool err = compute_header_data(argc, argv,
 		table.header.dim, table.header.xsize, table.header.ysize, table.header.zsize, table.header.data_size);
 
-	if (err) return Qnil;
+	if (err) {
+		rb_raise(rb_eRGSSError, "Table can be 1D, 2D or 3D but nothing else, requested dimension : %dD", argc);	
+		return Qnil;
+	}
 
 	// Then alloc data heap for this table 
 	if(table.heap != nullptr) {

--- a/unit-test/test_table.rb
+++ b/unit-test/test_table.rb
@@ -141,7 +141,7 @@ RSpec.describe Table do
     arr << table[0, 1, 1]
     expect(arr).to eq(Array.new(arr.size) { |i| i })
   end
-  
+
   it 'preserve the value on smaller resize (y)' do
     table = Marshal.load(data_table_with_values)
     table.resize(1, 1, 3)


### PR DESCRIPTION
Source issue:
https://gitlab.com/NuriYuri/pokemonsdk/issues/56

In rb_Table_resize function, the code calls rb_Table_initialize, which deallocates table's heap and allocate a new resized heap for it. 
This effectively removes the source heap which is needed for table_copy function. The source heap (deleted by rb_Table_initialized) is then dereferenced in table_copy with this line, which causes SIGSEGV:
```cpp
dheap[doy++] = sheap[soy++];
```

Solution:
This PR modifies the code in rb_Table_resize function so that it no longer depends on rb_Table_initialize. I refactor the code in rb_Table_initialize which only computes the header of the table (xsize, ysize, zsize, data_size and dim) into a new function compute_header_data. Then reuse this function in rb_Table_resize. The resized heap is computed inline using the header data computed from the new function.

Question:
compute_header_data function is used in both rb_Table_initialize and rb_Table_resize. If you want I can keep the old version of rb_Table_initialize.
