### PR TITLE
Allow for compiling on Mac w/ c++11

### DIFF
--- a/ext/LiteRGSS/extconf.rb
+++ b/ext/LiteRGSS/extconf.rb
@@ -18,4 +18,7 @@ if enable_config('debug')
     end
 end
 
+ASSEMBLE_CXX << ' -std=c++14'
+COMPILE_CXX << ' -std=c++14'
+
 create_makefile(ext_name)


### PR DESCRIPTION
This is to give Mac a flag to build with c++11